### PR TITLE
Fix uniform height of course cards

### DIFF
--- a/src/Scss/_Posts.scss
+++ b/src/Scss/_Posts.scss
@@ -45,6 +45,7 @@
 // courses post
 .courses-post{display: flex;justify-content: space-between;align-items: center;background: $darkgrey;border: 2px solid #434343;
     border-radius: 24px;margin-bottom:25px;gap: 10px;padding: 35px 35px;
+    height: 400px;width: 100%;
     position: relative;z-index: 2;
     &:before{
         position: absolute;left: 0;right: 0;bottom: 0;top: 0;@include trans1;
@@ -62,7 +63,7 @@
     &:hover:before{opacity: 1;}
     &:hover:after{opacity: 0;}
     @media(max-width:1200px){gap: 20px;padding: 30px 25px;}
-    @media(max-width:991px){flex-direction: column;}
+    @media(max-width:991px){flex-direction: column;height: auto;}
     @media(max-width:767px){padding: 30px 15px;}
     .icon-span{
         display: flex;justify-content: center;align-items: center;


### PR DESCRIPTION
## Summary
- set consistent 400px height for `.courses-post`
- allow cards to auto size on small screens

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa14d448c83249ac28656174bc3c9